### PR TITLE
tr Null handling:

### DIFF
--- a/scripts/Scene_Title.rb
+++ b/scripts/Scene_Title.rb
@@ -41,6 +41,7 @@ class Scene_Title
     end
     load_perma_flags
 	Window_Settings.load_settings
+    Oneshot.allow_exit true
 	
     @window_settings_title = Window_Settings.new
     # Make title graphic
@@ -227,6 +228,7 @@ class Scene_Title
     # Play decision SE
     Audio.se_play('Audio/SE/title_decision.wav')
     # Update map (run parallel process event)
+	Oneshot.allow_exit false
     $game_map.update
     # Switch to map screen
     $scene = Scene_Map.new

--- a/scripts/Window_Message.rb
+++ b/scripts/Window_Message.rb
@@ -204,6 +204,8 @@ class Window_Message < Window_Selectable
     return if @text_pause > 0
     # Don't do anything if we're done
     return if !@drawing_text
+	
+	autoMash = (Input.press?(Input::R) && $game_switches[253])
 
     # Get 1 text character in c (loop until unable to get text)
     while ((c = @text.slice!(0)) != nil)
@@ -227,13 +229,13 @@ class Window_Message < Window_Selectable
       # \.
       if c == "\001"
         # Pause
-        @text_pause = 10
+        @text_pause = autoMash ? 0 : 10
         return
       end
       # \|
       if c == "\002"
         # Pause
-        @text_pause = 10*4
+        @text_pause = autoMash ? 0 : 10*4
         return
       end
       if c == "\003"

--- a/scripts/i18n_Language.rb
+++ b/scripts/i18n_Language.rb
@@ -99,7 +99,11 @@ class Language
       else
         rv = string
       end
-      dbg_print(string + " -> " + rv)
+	  
+      if rv.nil?
+        rv = "NULL"
+	  end
+      #dbg_print(string + " -> " + rv)
       return String.new(rv)
     end
 


### PR DESCRIPTION
-adding safer null handling to tr(), to try to fix a bug with some older saves
-fixing issue where you can't close the game on the title screen
-making it so automash skips text pauses